### PR TITLE
Fix default params for ogl.setup()

### DIFF
--- a/lib/core/core.simba
+++ b/lib/core/core.simba
@@ -841,7 +841,7 @@ begin
   glxMapHooks(smart.pid);
 end;
 
-function tOGL.setup(funcDimensions:array[0..1] of int32=0;funcViewPort:array[0..3] of int32=[0,0,0,0]):boolean;
+function tOGL.setup(funcDimensions:array[0..1] of int32=[0,0];funcViewPort:array[0..3] of int32=[0,0,0,0]):boolean;
 begin
   clearDebug();
   writeLN(formatDateTime('tt',time()),' | ',self.getScriptName(),' > setup');


### PR DESCRIPTION
Error is thrown if user/script attempts to use the func with no params.
